### PR TITLE
Bugfix: Insert tex commands for Mathjax

### DIFF
--- a/example.qmd
+++ b/example.qmd
@@ -4,6 +4,8 @@ filters:
   - qmathpartir
 ---
 
+$\infer{ }{ \Gamma, x : \tau \vdash x : \tau }$
+
 ::: {.mathpar}
 e
 


### PR DESCRIPTION
Previously, these tex commands were only inserted if there was a mathpar paragraph (i.e., a Para node inside a mathpar Div). Now, these commands are inserted at the beginning of the document regardless.