### PR TITLE
Bugfix: Only insert commands in non-tex output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pdf
 *_files/
 /.luarc.json
+
+/.quarto/

--- a/README.md
+++ b/README.md
@@ -59,5 +59,6 @@ Here is the source code for a minimal example: [example.qmd](example.qmd).
 
 ## Version History
 
-v1.0.1 2023-01-12 Bugfix: Insert tex commands for Mathjax (#1)
-v1.0.0 2023-12-26 Initial version.
+- v1.0.2 2024-01-12 Bugfix: Only insert commands in non-tex output (#3)
+- v1.0.1 2024-01-12 Bugfix: Insert tex commands for Mathjax (#1)
+- v1.0.0 2023-12-26 Initial version.

--- a/_extensions/qmathpartir/_extension.yml
+++ b/_extensions/qmathpartir/_extension.yml
@@ -1,6 +1,6 @@
 title: Qmathpartir
 author: Bor-Yuh Evan Chang
-version: 1.0.1
+version: 1.0.2
 quarto-required: ">=1.3.0"
 contributes:
   filters:

--- a/_extensions/qmathpartir/qmathpartir.lua
+++ b/_extensions/qmathpartir/qmathpartir.lua
@@ -173,7 +173,11 @@ local mathjaxAdapter = pandoc.Span(math([[
 -- Entry point for the Pandoc document.
 function Pandoc(el)
   el = el:walk { Meta = mathparMeta, Div = mathparDiv }
-  -- After processing, insert some commands as a Mathjax block
-  table.insert(el.blocks, 1, mathjaxAdapter) 
+
+  if FORMAT ~= 'latex' then
+    -- After processing, insert some commands as a Mathjax block
+    table.insert(el.blocks, 1, mathjaxAdapter) 
+  end
+
   return el
 end

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,0 +1,7 @@
+project:
+  type: default
+
+format:
+  html: default
+  pdf: default
+

--- a/example.qmd
+++ b/example.qmd
@@ -30,14 +30,14 @@ e
 \\
 :::
 
-\newcommand{\int}{\text{int}}
+\newcommand{\tInt}{\text{int}}
 
 ::: {.mathpar}
 \infer[TypePlus]{
-  \Gamma \vdash e_1 : \int
+  \Gamma \vdash e_1 : \tInt
   \and
-  \Gamma \vdash e_1 : \int
+  \Gamma \vdash e_1 : \tInt
 }{
-  \Gamma \vdash e_1 + e_2 : \int
+  \Gamma \vdash e_1 + e_2 : \tInt
 }
 :::


### PR DESCRIPTION
The inserting of the `\newcommand{\infer}{...}` and other tex commands should only be done in non-tex output.